### PR TITLE
Add/additional info fields

### DIFF
--- a/ckanext/montreal/donneesqc_metadonnee_scheming.json
+++ b/ckanext/montreal/donneesqc_metadonnee_scheming.json
@@ -44,6 +44,20 @@
             "help_text" : "Se référer au Thésaurus de l'activité gouvernementale (http://www.thesaurus.gouv.qc.ca/) Ex. transport.",
             "inline" : false
         },
+        {   "field_name": "metadata_created",
+            "form_snippet": "local_friendly_datetime.html",
+            "label": {
+                "en": "Created",
+                "fr": "Créé le"
+            }
+        },
+        {   "field_name": "metadata_modified",
+            "form_snippet": "local_friendly_datetime.html",
+            "label": {
+                "en": "Last modification",
+                "fr": "Dernière modification"
+            }
+        },
         {
             "field_name": "license_id",
             "required": true,

--- a/ckanext/montreal/donneesqc_metadonnee_scheming.json
+++ b/ckanext/montreal/donneesqc_metadonnee_scheming.json
@@ -44,20 +44,6 @@
             "help_text" : "Se référer au Thésaurus de l'activité gouvernementale (http://www.thesaurus.gouv.qc.ca/) Ex. transport.",
             "inline" : false
         },
-        {   "field_name": "metadata_created",
-            "form_snippet": "local_friendly_datetime.html",
-            "label": {
-                "en": "Created",
-                "fr": "Créé le"
-            }
-        },
-        {   "field_name": "metadata_modified",
-            "form_snippet": "local_friendly_datetime.html",
-            "label": {
-                "en": "Last modification",
-                "fr": "Dernière modification"
-            }
-        },
         {
             "field_name": "license_id",
             "required": true,

--- a/ckanext/montreal/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/montreal/templates/scheming/package/snippets/additional_info.html
@@ -14,16 +14,35 @@
 
 {% block package_additional_info %}
   {%- for field in schema.dataset_fields -%}
-    {%- if field.field_name not in exclude_fields
-        and field.display_snippet is not none -%}
-      <tr>
-        <th scope="row" class="dataset-label">{{
-          h.scheming_language_text(field.label) }}</th>
-        <td class="dataset-details"{%
-          if field.display_property %} property="{{ field.display_property
-          }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
-          field=field, data=pkg_dict, schema=schema -%}</td>
-      </tr>
+    {%- if field.field_name not in exclude_fields and field.display_snippet is not none -%}
+      {%- if field.field_name|string() != "metadata_created" and field.field_name|string() != "metadata_modified" -%}
+        <tr>
+          <th scope="row" class="dataset-label">
+            {{ h.scheming_language_text(field.label) }}
+          </th>
+          <td class="dataset-details" {% if field.display_property %} property="{{ field.display_property }}" {% endif %}>
+            {%- snippet 'scheming/snippets/display_field.html', field=field, data=pkg_dict, schema=schema -%}
+          </td>
+        </tr>
+      {%- elif field.field_name|string() == "metadata_created"-%}
+        <tr>
+          <th scope="row" class="dataset-label">
+            {{ h.scheming_language_text(field.label) }}
+          </th>
+          <td class="dataset-details" {% if field.display_property %} property="{{ field.display_property }}" {% endif %}>
+            {{ h.render_datetime(pkg_dict.metadata_created, date_format='%Y-%m-%d %H:%M') }}
+          </td>
+        </tr>
+      {%- else -%}
+        <tr>
+          <th scope="row" class="dataset-label">
+            {{ h.scheming_language_text(field.label) }}
+          </th>
+          <td class="dataset-details" {% if field.display_property %} property="{{ field.display_property }}" {% endif %}>
+            {{ h.render_datetime(pkg_dict.metadata_modified, date_format='%Y-%m-%d %H:%M') }}
+          </td>
+        </tr>
+      {%- endif -%}
     {%- endif -%}
   {%- endfor -%}
   {% if h.check_access('package_update',{'id':pkg_dict.id}) %}

--- a/ckanext/montreal/templates/scheming/package/snippets/additional_info.html
+++ b/ckanext/montreal/templates/scheming/package/snippets/additional_info.html
@@ -14,37 +14,37 @@
 
 {% block package_additional_info %}
   {%- for field in schema.dataset_fields -%}
-    {%- if field.field_name not in exclude_fields and field.display_snippet is not none -%}
-      {%- if field.field_name|string() != "metadata_created" and field.field_name|string() != "metadata_modified" -%}
-        <tr>
-          <th scope="row" class="dataset-label">
-            {{ h.scheming_language_text(field.label) }}
-          </th>
-          <td class="dataset-details" {% if field.display_property %} property="{{ field.display_property }}" {% endif %}>
-            {%- snippet 'scheming/snippets/display_field.html', field=field, data=pkg_dict, schema=schema -%}
-          </td>
-        </tr>
-      {%- elif field.field_name|string() == "metadata_created"-%}
-        <tr>
-          <th scope="row" class="dataset-label">
-            {{ h.scheming_language_text(field.label) }}
-          </th>
-          <td class="dataset-details" {% if field.display_property %} property="{{ field.display_property }}" {% endif %}>
-            {{ h.render_datetime(pkg_dict.metadata_created, date_format='%Y-%m-%d %H:%M') }}
-          </td>
-        </tr>
-      {%- else -%}
-        <tr>
-          <th scope="row" class="dataset-label">
-            {{ h.scheming_language_text(field.label) }}
-          </th>
-          <td class="dataset-details" {% if field.display_property %} property="{{ field.display_property }}" {% endif %}>
-            {{ h.render_datetime(pkg_dict.metadata_modified, date_format='%Y-%m-%d %H:%M') }}
-          </td>
-        </tr>
-      {%- endif -%}
+    {%- if field.field_name not in exclude_fields
+        and field.display_snippet is not none -%}
+      <tr>
+        <th scope="row" class="dataset-label">{{
+          h.scheming_language_text(field.label) }}</th>
+        <td class="dataset-details"{%
+          if field.display_property %} property="{{ field.display_property
+          }}"{% endif %}>{%- snippet 'scheming/snippets/display_field.html',
+          field=field, data=pkg_dict, schema=schema -%}</td>
+      </tr>
     {%- endif -%}
   {%- endfor -%}
+
+  {% if pkg_dict.metadata_created %}
+    <tr>
+      <th scope="row" class="dataset-label">{{ _("Created") }}</th>
+      <td class="dataset-details">
+        {{ h.render_datetime(pkg_dict.metadata_created, date_format='%Y-%m-%d %H:%M') }}
+      </td>
+    </tr>
+  {% endif %}
+
+  {% if pkg_dict.metadata_modified %}
+    <tr>
+      <th scope="row" class="dataset-label">{{ _("Last Updated") }}</th>
+      <td class="dataset-details">
+        {{ h.render_datetime(pkg_dict.metadata_modified, date_format='%Y-%m-%d %H:%M') }}
+      </td>
+    </tr>
+  {% endif %}
+
   {% if h.check_access('package_update',{'id':pkg_dict.id}) %}
     <tr>
       <th scope="row" class="dataset-label">{{ _("State") }}</th>


### PR DESCRIPTION
@anuveyatsu Please, can you review this?

This fixes https://gitlab.com/datopian/clients/ckan-montreal/-/issues/144

On the old portal https://data.montreal.ca/dataset/permis-construction in `Additional info` section, there were two fields: 
`Date created` and `Last modified` 

![image](https://user-images.githubusercontent.com/12686547/87222551-a92ad280-c374-11ea-90dd-35831d4149c9.png)

which are not showing on the new backend https://montreal-dev.ckan.io/dataset/permis-construction.

After these changes `Additional info` section looks like following screenshot (tested locally)

![](https://i.imgur.com/sSDyq9x.png)

This closes https://gitlab.com/datopian/clients/ckan-montreal/-/issues/144